### PR TITLE
GAdev -> making crossover more undestandable and fixing mutate index error

### DIFF
--- a/Cuda/Genetic_Algorithm/ga_crossover.cpp
+++ b/Cuda/Genetic_Algorithm/ga_crossover.cpp
@@ -352,7 +352,7 @@ int newGeneration(Individual *survivors, Individual *pool, int survivorSize, int
     int newIndCount = 0; // Number of new individuals created so far (initially none), used in navigating through the pool when creating new individuals and returned at end of function
     int numPairs = survivorSize / 2; // Value for how many pairs to produce with each type of mask
 
-    // Generate two offspring through each crossover method, total of 8 offspring per parent pair
+    // Generate two offspring through each crossover method, total is 4 * numPairs offspring in pool
     for (int i = 0; i < numPairs; i++) {
         crossOver_wholeRandom(mask, rng);
         generateChildrenPair(pool, survivors, mask, newIndCount, 2*i, annealing, poolSize, rng, cConstants, thrust);

--- a/Cuda/Genetic_Algorithm/ga_crossover.cpp
+++ b/Cuda/Genetic_Algorithm/ga_crossover.cpp
@@ -143,12 +143,13 @@ void crossOver_average(int * mask) {
 // output: each 1 in mask will be reassigned to be a 2, each 2 will be reassigned 1
 void flipMask(int * mask) {
     for (int i = 0; i < OPTIM_VARS; i++) {
-        if (mask[i] == 1) {
-            mask[i] = 2;
+        if (mask[i] == PARTNER1) {
+            mask[i] = PARTNER2;
         }
-        else {
-            mask[i] = 1;
+        else if (mask[i] == PARTNER2) {
+            mask[i] = PARTNER1;
         }
+        // If mask[i] is neither partner1 nor partner2 (must be avg then), leave it be
     }
     return;
 }
@@ -317,88 +318,66 @@ rkParameters<double> mutate(const rkParameters<double> & p1, std::mt19937_64 & r
 }
 
 
-// if using this, consider that theta is the same as theta + 2 pi
-// CURRENTLY NOT USED
-//Creates a new rkParameter based on the average between p1 and p2
-// input: p1 and p2 are valid rkParameters
-// output: average of the two
-/*rkParameters<double> generateNewIndividual_avg(const rkParameters<double> & p1, const rkParameters<double> & p2, thruster<double>& thrust) {
-    rkParameters<double> newInd;
-    
-    // alter thrust coefficients only when using a thruster
-    if (thrust.type != thruster<double>::NO_THRUST) {
-        for (int i = 0; i < p1.coeff.gammaSize; i++) {
-            newInd.coeff.gamma[i] = (p1.coeff.gamma[i]/2.0) + (p2.coeff.gamma[i]/2.0);
-        }
-        for (int i = 0; i < p1.coeff.tauSize; i++) {
-            newInd.coeff.tau[i] = (p1.coeff.tau[i]/2.0) + (p2.coeff.tau[i]/2.0);
-        }
-        for (int i = 0; i < p1.coeff.coastSize; i++) {
-            newInd.coeff.coast[i] = (p1.coeff.coast[i]/2.0) + (p2.coeff.coast[i]/2.0);
-        }
-    }
+// Create a new individual, using two parents with a mask and also possible mutation
+// Input: Indiviudal array pool to put new indiviudal and Indiviudal array to get parents from (survivors) 
+void mutateNewIndividual(Individual *pool, Individual *survivors, int * mask, int parent1Index, int parent2Index, int newIndividualIndex, double annealing, int poolSize, std::mt19937_64 & rng, const cudaConstants* cConstants, thruster<double>& thrust) {
 
-    newInd.alpha = (p1.alpha/2.0) + (p2.alpha/2.0);
-    newInd.beta = (p1.beta/2.0) + (p2.beta/2.0);
-    newInd.zeta = (p1.zeta/2.0) + (p2.zeta/2.0);
-    newInd.tripTime = (p1.tripTime/2.0) + (p2.tripTime/2.0);
+    // Generate a new individual, using the parents and mask
+    pool[newIndividualIndex] = Individual();
+    pool[newIndividualIndex].startParams = generateNewIndividual(survivors[parent1Index].startParams, survivors[parent2Index].startParams, mask, thrust, cConstants);
 
-    return newInd;    
-}*/
-
-// WIP
-// Uses generateNewIndividual to create new Individuals by crossing over properties with mask, followed by random chance for mutations
-// Output is 2 new individual in pool
-// Can only be used within crossover function in its current state because of int i input
-void mutateNewIndividual(Individual *pool, Individual *survivors, int mask[], int index, int i, double annealing, int poolSize, std::mt19937_64 & rng, const cudaConstants* cConstants, thruster<double>& thrust) {
-    pool[poolSize - 1 - (2 * index)] = Individual(); // create a new Individual instead of overwriting values
-    pool[poolSize - 1 - (2 * index)].startParams = generateNewIndividual(survivors[2*i].startParams, survivors[(2*i)+1].startParams, mask, thrust, cConstants);
-    
-    if (rng() % 100 < cConstants->mutation_rate * 100) { // a certain chance of mutation
-        pool[poolSize - 1 - (2 * index)].startParams = mutate(pool[poolSize - 1 - (4 * index)].startParams, rng, annealing, cConstants, thrust);
-    }
-
-    flipMask(mask); // get the opposite offspring
-    pool[poolSize - 1 - (2 * index) - 1] = Individual();
-    pool[poolSize - 1 - (2 * index) - 1].startParams = generateNewIndividual(survivors[2*i].startParams, survivors[(2*i)+1].startParams, mask, thrust, cConstants);
-    
+    // With percent chance of occurring, perform a mutation on the new individual's starting params
     if (rng() % 100 < cConstants->mutation_rate * 100) {
-        pool[poolSize - 1 - (2 * index) - 1].startParams = mutate(pool[poolSize - 1 - (4 * index) - 1].startParams, rng, annealing, cConstants, thrust);
+        pool[newIndividualIndex].startParams = mutate(pool[newIndividualIndex].startParams, rng, annealing, cConstants, thrust);
     }
 }
 
+// Method that takes in a pool and survivors with some info on where to put the new individuals 
+void generateChildrenPair(Individual *pool, Individual *survivors, int * mask, int& newIndCount, int i, double annealing, int poolSize, std::mt19937_64 & rng, const cudaConstants* cConstants, thruster<double>& thrust) { 
+    // Determine where the parents and the new individual being created are located in the pool
+    int parent1Index = 2*i;
+    int parent2Index = 2*i + 1;
 
-int nextGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* cConstants, thruster<double>& thrust) {
+    int newIndividualIndex = poolSize - 1 - newIndCount;    // The new indiviudal is located at the end of the pool, up the number of new individuals already created
+    // Generate new offspring with mask
+    mutateNewIndividual(pool, survivors, mask, parent1Index, parent2Index, newIndividualIndex, annealing, poolSize, rng, cConstants, thrust);
+    newIndCount++;
+
+    // Get the opposite offspring
+    newIndividualIndex--; // Decrement newIndividualIndex value to access where the next individual must be as newIndCount has increased
+    flipMask(mask);
+    mutateNewIndividual(pool, survivors, mask, parent1Index, parent2Index, newIndividualIndex, annealing, poolSize, rng, cConstants, thrust);
+    newIndCount++;
+}
+
+
+int newGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* cConstants, thruster<double>& thrust) {
     std::mt19937_64 rng(cConstants->time_seed);
 
     int * mask = new int[OPTIM_VARS];
 
-    int index = 0;
+    int newIndCount = 0; // Number of new individuals created so far, also used in navigating through the pool when creating new individuals
+    int numPairs = survivorSize / 2; // Value for how many pairs to produce with each type of mask
 
     // Generate two offspring through each crossover method, total of 8 offspring per parent pair
-    for (int i = 0; i < survivorSize / 2; i++) {
+    for (int i = 0; i < numPairs; i++) {
         crossOver_wholeRandom(mask, rng);
-        mutateNewIndividual(pool, survivors, mask, index, i, annealing, poolSize, rng, cConstants, thrust);
-        index++;
+        generateChildrenPair(pool, survivors, mask, newIndCount, i, annealing, poolSize, rng, cConstants, thrust);
     }
 
-    for (int i = 0; i < survivorSize / 2; i++) {
+    for (int i = 0; i < numPairs; i++) {
         crossOver_average(mask);
-        mutateNewIndividual(pool, survivors, mask, index, i, annealing, poolSize, rng, cConstants, thrust);
-        index++;
+        generateChildrenPair(pool, survivors, mask, newIndCount, i, annealing, poolSize, rng, cConstants, thrust);
+    }
+    for (int i = 0; i < numPairs; i++) {
+        crossOver_bundleVars(mask, rng);
+        generateChildrenPair(pool, survivors, mask, newIndCount, i, annealing, poolSize, rng, cConstants, thrust);
+    }
+    for (int i = 0; i < numPairs; i++) {
+        crossOver_bundleVars(mask, rng);
+        generateChildrenPair(pool, survivors, mask, newIndCount, i, annealing, poolSize, rng, cConstants, thrust);
     }
 
-    for (int i = 0; i < survivorSize / 2; i++) {
-        crossOver_bundleVars(mask, rng);
-        mutateNewIndividual(pool, survivors, mask, index, i, annealing, poolSize, rng, cConstants, thrust);
-        index++;
-    }
-
-    for(int i = 0; i < survivorSize / 2; i++){
-        crossOver_bundleVars(mask, rng);
-        mutateNewIndividual(pool, survivors, mask, index, i, annealing, poolSize, rng, cConstants, thrust);
-        index++;
-    }
     delete [] mask;
-    return index * 2;
+    return newIndCount;
 }

--- a/Cuda/Genetic_Algorithm/ga_crossover.cpp
+++ b/Cuda/Genetic_Algorithm/ga_crossover.cpp
@@ -368,7 +368,7 @@ void mutateNewIndividual(Individual *pool, Individual *survivors, int mask[], in
 }
 
 
-int crossover(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* cConstants, thruster<double>& thrust) {
+int nextGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* cConstants, thruster<double>& thrust) {
     std::mt19937_64 rng(cConstants->time_seed);
 
     int * mask = new int[OPTIM_VARS];

--- a/Cuda/Genetic_Algorithm/ga_crossover.h
+++ b/Cuda/Genetic_Algorithm/ga_crossover.h
@@ -35,7 +35,7 @@ void mutateNewIndividual(Individual *pool, Individual *survivors, int mask[], in
 // generates new Individuals from the survivors(winners of competition) and replaces the worst Individuals in the pool(population) with these new ones
 // Uses mutateNewIndividual and the crossOver mask methods
 // returns the number of new Individuals put into the pool
-int crossover(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* gConstant, thruster<double>& thrust);
+int nextGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* gConstant, thruster<double>& thrust);
 
 void crossOver_randHalf(int mask[], std::mt19937_64 & rng);
 

--- a/Cuda/Genetic_Algorithm/ga_crossover.h
+++ b/Cuda/Genetic_Algorithm/ga_crossover.h
@@ -35,7 +35,7 @@ void mutateNewIndividual(Individual *pool, Individual *survivors, int mask[], in
 // generates new Individuals from the survivors(winners of competition) and replaces the worst Individuals in the pool(population) with these new ones
 // Uses mutateNewIndividual and the crossOver mask methods
 // returns the number of new Individuals put into the pool
-int nextGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* gConstant, thruster<double>& thrust);
+int newGeneration(Individual *survivors, Individual *pool, int survivorSize, int poolSize, double annealing, const cudaConstants* gConstant, thruster<double>& thrust);
 
 void crossOver_randHalf(int mask[], std::mt19937_64 & rng);
 

--- a/Cuda/Genetic_Algorithm/optimization.cu
+++ b/Cuda/Genetic_Algorithm/optimization.cu
@@ -289,7 +289,7 @@ double optimize(const int numThreads, const int blockThreads, const cudaConstant
         }
 
         // Create a new generation and increment the generation counter
-        newInd = nextGeneration(survivors, inputParameters, cConstants->survivor_count, numThreads, new_anneal, cConstants, thrust);
+        newInd = newGeneration(survivors, inputParameters, cConstants->survivor_count, numThreads, new_anneal, cConstants, thrust);
         ++generation;
         
         // If the current distance is still higher than the tolerance we find acceptable, perform the loop again

--- a/Cuda/Genetic_Algorithm/optimization.cu
+++ b/Cuda/Genetic_Algorithm/optimization.cu
@@ -289,7 +289,7 @@ double optimize(const int numThreads, const int blockThreads, const cudaConstant
         }
 
         // Create a new generation and increment the generation counter
-        newInd = crossover(survivors, inputParameters, cConstants->survivor_count, numThreads, new_anneal, cConstants, thrust);
+        newInd = nextGeneration(survivors, inputParameters, cConstants->survivor_count, numThreads, new_anneal, cConstants, thrust);
         ++generation;
         
         // If the current distance is still higher than the tolerance we find acceptable, perform the loop again


### PR DESCRIPTION
crossover has been renamed newGeneration for clarity of actual purpose, functionalized more of the contents of the for loops and also tweaked values to be more clear as to where they are derived from.  Also had found and fixed a mutate error where the wrong parameters were being used that had effectively been removing impact of crossover masks.  So far have not been noticing any significant impact on the genetic algorithm's performance.